### PR TITLE
chore: remove assumptions from B_eq_B_of_same_matroid_same_X_aux

### DIFF
--- a/Seymour/Matroid/Constructors/StandardRepresentation.lean
+++ b/Seymour/Matroid/Constructors/StandardRepresentation.lean
@@ -256,7 +256,7 @@ private lemma B_eq_B_of_same_matroid_same_X_aux {X Y : Set α} {B : Matrix Y X Z
     {hX : ∀ a, Decidable (a ∈ X)} {hY : ∀ a, Decidable (a ∈ Y)} (hXXY : X ⊆ X ∪ Y) (hYXY : Y ⊆ X ∪ Y) -- redundant but keep
     {D : Set X} {y : Y}
     {l : (X ∪ Y).Elem →₀ Z2} (hl : ∀ e ∈ l.support, e.val ∈ y.val ᕃ Subtype.val '' D) (hly : l (hYXY.elem y) = 0)
-    [Fintype (X ↓∩ l.support.toSet).Elem]
+    [Fintype (X ↓∩ l.support.toSet)]
     {i : (X ∪ Y).Elem} (hiX : i.val ∈ X) (hlBi : ∑ a ∈ l.support, l a • B.uppendId a.toSum ⟨i, hiX⟩ = 0) :
     ∑ a ∈ (X ↓∩ Subtype.val '' l.support.toSet).toFinset, l (hXXY.elem a) • B.uppendId (hXXY.elem a).toSum ⟨i, hiX⟩ = 0 := by
   have hlXXY : l.support.toSet ⊆ hXXY.elem.range


### PR DESCRIPTION
nested simp lemmas were hiding the useless `hyDXY` and `hil` assumptions. This originally was to remove the fintype instance from `B_eq_B_of_same_matroid_same_X_aux`, but these hypotheses removals seemed useful on their own.

*Note*: this does expand some of the heavy calls to constrain the heartbeat count of the proof, but unfortunately, that does increase the size of the proof.

I've opened up a [Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60.20.E2.86.93.E2.88.A9.20.60.20for.20Finset/with/508671805) for addressing the Fintype instance for later.