### PR TITLE
feat: Matrix.testTotallyUnimodularFastest

### DIFF
--- a/Seymour.lean
+++ b/Seymour.lean
@@ -1,3 +1,1 @@
 import Seymour.HardDirection -- the final file
-
-import Seymour.Matrix.TotalUnimodularityTest -- currently not used

--- a/Seymour/EasyDirection.lean
+++ b/Seymour/EasyDirection.lean
@@ -22,9 +22,7 @@ theorem Matroid.IsGood.isRegular {M : Matroid α} (hM : M.IsGood) : M.IsRegular 
   induction hM with
   | graphic hM => exact hM.isRegular
   | cographic hM => exact hM.isRegular
-  | @isomorphicR10 M e hM =>
-    have : (M.mapEquiv e).IsRegular := by simp_all [matroidR10.isRegular]
-    exact Matroid.IsRegular.mapEquiv.→ this
+  | @isomorphicR10 M e hM => simp [←M.isRegular_mapEquiv_iff e, hM]
   | is1sum hM _ _ ih₁ ih₂ => exact hM.isRegular ih₁ ih₂
   | is2sum hM _ _ ih₁ ih₂ => exact hM.isRegular ih₁ ih₂
   | is3sum hM _ _ ih₁ ih₂ => exact hM.isRegular ih₁ ih₂

--- a/Seymour/EasyDirection.lean
+++ b/Seymour/EasyDirection.lean
@@ -2,22 +2,7 @@ import Seymour.Matroid.Operations.Sum1
 import Seymour.Matroid.Operations.Sum2
 import Seymour.Matroid.Operations.Sum3
 import Seymour.Matroid.Notions.Graphicness
-
-
-/-- Matroid R10. -/
-def matroidR10 : StandardRepr (Fin 10) Z2 where
-  X := (·.val < 5)
-  Y := (·.val ≥ 5)
-  hXY := by
-    rw [Set.disjoint_left]
-    intro _ hX hY
-    rw [Set.mem_def] at hX hY
-    omega
-  B := !![1, 0, 0, 1, 1; 1, 1, 0, 0, 1; 0, 1, 1, 0, 1; 0, 0, 1, 1, 1; 1, 1, 1, 1, 1].submatrix
-    (fun i => ⟨i.val, i.property⟩)
-    (fun j => ⟨j.val - 5, by omega⟩)
-  decmemX := (·.val.decLt 5)
-  decmemY := Fin.decLe 5
+import Seymour.Matroid.Special.R10
 
 variable {α : Type} [DecidableEq α]
 

--- a/Seymour/EasyDirection.lean
+++ b/Seymour/EasyDirection.lean
@@ -22,7 +22,9 @@ theorem Matroid.IsGood.isRegular {M : Matroid α} (hM : M.IsGood) : M.IsRegular 
   induction hM with
   | graphic hM => exact hM.isRegular
   | cographic hM => exact hM.isRegular
-  | isomorphicR10 hM => sorry
+  | @isomorphicR10 M e hM =>
+    have : (M.mapEquiv e).IsRegular := by simp_all [matroidR10.isRegular]
+    exact Matroid.IsRegular.mapEquiv.→ this
   | is1sum hM _ _ ih₁ ih₂ => exact hM.isRegular ih₁ ih₂
   | is2sum hM _ _ ih₁ ih₂ => exact hM.isRegular ih₁ ih₂
   | is3sum hM _ _ ih₁ ih₂ => exact hM.isRegular ih₁ ih₂

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -55,16 +55,6 @@ abbrev Matrix.square_set_submatrix {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ)
     rw [Finset.length_sort, show c.card = r.card by simp_all only [Fintype.card_coe], ←Fintype.card_coe r]
     exact Fin.isLt p))
 
-/-- Faster algorithm for testing total unimodularity but without formal guarantees. -/
-def Matrix.testTotallyUnimodularFaster {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) : Bool :=
-  (∀ k : ℕ, k < min m n → ∀ x : Fin k → Fin m, ∀ y : Fin k → Fin n, (A.submatrix x y).det ∈ SignType.cast.range) ∧ (
-    if hmn : m = n
-      then (A.submatrix id (finCongr hmn)).det ∈ SignType.cast.range
-    else if m < n
-      then (∀ y : Fin m → Fin n, (A.submatrix id y).det ∈ SignType.cast.range)
-      else (∀ x : Fin n → Fin m, (A.submatrix x id).det ∈ SignType.cast.range)
-  )
-
 /-- Faster algorithm for testing total unimodularity without permutation with pending formal guarantees. -/
 def Matrix.testTotallyUnimodularFastest {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) : Bool :=
   ∀ (r : Finset (Fin m)) (c : Finset (Fin n)) (h : #r = #c),
@@ -146,7 +136,8 @@ lemma Matrix.submatrix_eq_submatrix_reindex {r c n o p q : Type}
   refine ⟨e₁.symm, e₂.symm, ?_⟩
   simp
 
-lemma Matrix.isTotallyUnimodular_of_testTotallyUnimodularFastest {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) :
+/-- A fast version of `Matrix.testTotallyUnimodular` which doesn't test every permutation. -/
+lemma Matrix.isTotallyUnimodular_of_testTotallyUnimodularFast {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) :
     A.testTotallyUnimodularFastest → A.IsTotallyUnimodular := by
   rw [testTotallyUnimodularFastest]
   intro a k f g hf hg

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -146,8 +146,8 @@ lemma Matrix.isTotallyUnimodular_of_testTotallyUnimodularFast {m n : ℕ} (A : M
   have hfg : f.range.toFinset.card = g.range.toFinset.card := (by
     simp_rw [Function.range, Set.toFinset_card, Set.card_range_of_injective hf, Set.card_range_of_injective hg])
   obtain ⟨e₁, e₂, hee⟩ := @Matrix.submatrix_eq_submatrix_reindex
-    (Fin m) (Fin n) (Fin (#{ x // x ∈ f.range.toFinset })) (Fin (#{ x // x ∈ f.range.toFinset })) (Fin k) (Fin k)
-    _ _ _ _ _ _  _ _ _ _ _ _ ℚ _
+    _ _ (Fin (#{ x // x ∈ f.range.toFinset })) (Fin (#{ x // x ∈ f.range.toFinset })) _ _
+    _ _ _ _ _ _  _ _ _ _ _ _ _ _
     (fun x => (f.range.toFinset.sort (· ≤ ·))[x]'(by
       rw [Finset.length_sort, ←Fintype.card_coe f.range.toFinset]
       exact Fin.isLt x

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -1,6 +1,7 @@
 import Mathlib.LinearAlgebra.Matrix.Determinant.TotallyUnimodular
 import Mathlib.Data.Fintype.Card
 import Seymour.Basic.Basic
+import Seymour.Basic.SignTypeCast
 
 
 /-- Formally verified algorithm for testing total unimodularity. -/
@@ -48,7 +49,7 @@ theorem Matrix.testTotallyUnimodular_eq_isTotallyUnimodular {m n : ℕ} (A : Mat
 instance {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) : Decidable A.IsTotallyUnimodular :=
   decidable_of_iff _ A.testTotallyUnimodular_eq_isTotallyUnimodular
 
-def Matrix.square_set_submatrix {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ)
+abbrev Matrix.square_set_submatrix {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ)
       (r : Finset (Fin m)) (c : Finset (Fin n)) (h : #r = #c) :=
   @Matrix.submatrix (Fin (#r)) _ _ (Fin (#r)) ℚ A ((r.sort (· ≤ ·))[·]) (fun p ↦ (c.sort (· ≤ ·))[p]'(by
       rw [Finset.length_sort, show c.card = r.card by simp_all only [Fintype.card_coe]]
@@ -72,15 +73,96 @@ def Matrix.testTotallyUnimodularFastest {m n : ℕ} (A : Matrix (Fin m) (Fin n) 
   ∀ (r : Finset (Fin m)) (c : Finset (Fin n)) (h : #r = #c),
     (A.square_set_submatrix r c h).det ∈ SignType.cast.range
 
+-- Lemmas that should all be upstreamed to mathlib
+lemma Matrix.det_reindex_self_self {m n : Type} [DecidableEq n] [Fintype n]
+      [DecidableEq m] [Fintype m]
+      {R : Type} [LinearOrderedCommRing R] (e₁ e₂ : m ≃ n) (A : Matrix m m R) :
+    |((reindex e₁ e₂) A).det| = |A.det| :=
+  Matrix.abs_det_submatrix_equiv_equiv e₁.symm e₂.symm A
+
+lemma Set.range_eq_range_iff_exists_comp_equiv {α β γ : Type}
+      {f : α → γ} {g : β → γ} (hf : f.Injective) (hg : g.Injective) :
+    Set.range f = Set.range g ↔ ∃ (h : α ≃ β), f = g ∘ h := by
+  constructor
+  · classical
+    intro hfg
+    let j := fun (a : α) =>
+      have : ∃ (b : β), g b = f a := by
+        simp_rw [range, Set.ext_iff] at hfg
+        have := (hfg (f a)).→ (by simp)
+        exact this
+      this.choose
+    have hji : j.Injective := by sorry
+    have hjs : j.Surjective := by sorry
+    use Equiv.ofBijective j ⟨hji, hjs⟩
+    simp only [Function.comp_def, funext_iff, Equiv.ofBijective_apply]
+    unfold j
+    intro x
+    simp only
+    sorry
+  · intro ⟨e, he⟩
+    simp_rw [range]
+    ext x
+    subst he
+    simp_all only [Function.Injective.of_comp_iff, Function.comp_apply, mem_setOf_eq]
+    constructor <;> intro ⟨w, h⟩ <;> subst h
+    · simp_all only [exists_apply_eq_apply]
+    · use e.symm w
+      simp
+
+lemma Matrix.submatrix_eq_submatrix_reindex {r c n o p q : Type}
+      [DecidableEq r] [Fintype r] [DecidableEq c] [Fintype c] [DecidableEq n] [Fintype n]
+      [DecidableEq o] [Fintype o] [DecidableEq p] [Fintype p] [DecidableEq q] [Fintype q]
+      {R : Type} [CommRing R]
+      {nr : n → r} {oc : o → c} {pr : p → r} {qc : q → c}
+      (hnr : nr.Injective) (hoc : oc.Injective) (hpr : pr.Injective) (hqc : qc.Injective)
+      (hnpr : nr.range = pr.range) (hoqc : oc.range = qc.range)
+      (A : Matrix r c R) :
+    ∃ e₁ e₂, (A.submatrix nr oc) = (A.submatrix pr qc).reindex e₁ e₂ := by
+  have ⟨e₁, he₁⟩ : ∃ (e : n ≃ p), nr = pr ∘ e := (Set.range_eq_range_iff_exists_comp_equiv hnr hpr).→ (by tauto_set)
+  have ⟨e₂, he₂⟩ : ∃ (e : o ≃ q), oc = qc ∘ e := (Set.range_eq_range_iff_exists_comp_equiv hoc hqc).→ (by tauto_set)
+  refine ⟨e₁.symm, e₂.symm, ?_⟩
+  subst he₁ he₂
+  simp
+
 lemma Matrix.isTotallyUnimodular_of_testTotallyUnimodularFastest {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) :
     A.testTotallyUnimodularFastest → A.IsTotallyUnimodular := by
   rw [testTotallyUnimodularFastest]
   intro a k f g hf hg
-  simp_all only [Fintype.card_coe, Function.range, Fin.getElem_fin, Set.mem_range,
+  simp_all only [Fintype.card_coe, Function.range, Fin.getElem_fin,
     decide_eq_true_eq]
+  simp_rw [(in_signTypeCastRange_iff_abs (A.submatrix f g).det)]
   have hfg : f.range.toFinset.card = g.range.toFinset.card := (by
     simp_rw [Function.range, Set.toFinset_card, Set.card_range_of_injective hf, Set.card_range_of_injective hg])
+  obtain ⟨e₁, e₂, hee⟩ := @Matrix.submatrix_eq_submatrix_reindex
+    (Fin m) (Fin n) (Fin (#{ x // x ∈ f.range.toFinset })) (Fin (#{ x // x ∈ f.range.toFinset })) (Fin k) (Fin k)
+    _ _ _ _ _ _  _ _ _ _ _ _ ℚ _
+    (fun x => (Finset.sort (fun x1 x2 => x1 ≤ x2) f.range.toFinset)[x]'(by
+      rw [Finset.length_sort]
+      calc
+        x.val < #{ x // x ∈ f.range.toFinset } := Fin.isLt x
+        _ = _ := by simp_all only [Fintype.card_coe]
+      ))
+    (fun p => (Finset.sort (fun x1 x2 => x1 ≤ x2) g.range.toFinset)[p]'(by
+      rw [Finset.length_sort, show g.range.toFinset.card = f.range.toFinset.card by simp_all only [Fintype.card_coe]]
+      calc
+        p.val < #{ x // x ∈ f.range.toFinset } := Fin.isLt p
+        _ = _ := by simp_all only [Fintype.card_coe])) f g
+    (by
+      sorry)
+    (by
+      sorry)
+    hf hg
+    (by
+      simp only [Function.range, Set.toFinset_range, Fin.getElem_fin, ←Finset.univ_filter_mem_range]
+      ext x
+      sorry)
+    (by
+      simp only [Function.range, Set.toFinset_range, Fin.getElem_fin, ←Finset.univ_filter_mem_range]
+      ext x
+      sorry)
+    A
   have := a f.range.toFinset g.range.toFinset hfg
-  peel this with s hs
-  rw [hs]
-  sorry
+  rw [square_set_submatrix, hee, in_signTypeCastRange_iff_abs (((reindex e₁ e₂) (A.submatrix f g))).det] at this
+  rw [←Matrix.det_reindex_self_self e₁ e₂ (A.submatrix f g)]
+  exact this

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -61,7 +61,8 @@ def Matrix.testTotallyUnimodularFastest {m n : ℕ} (A : Matrix (Fin m) (Fin n) 
     (A.square_set_submatrix r c h).det ∈ SignType.cast.range
 
 -- Lemmas that should all be upstreamed to mathlib
-lemma Matrix.det_reindex_self_self {m n : Type} [DecidableEq n] [Fintype n]
+-- https://github.com/leanprover-community/mathlib4/pull/23421/files
+lemma Matrix.abs_det_reindex_self_self {m n : Type} [DecidableEq n] [Fintype n]
       [DecidableEq m] [Fintype m]
       {R : Type} [LinearOrderedCommRing R] (e₁ e₂ : m ≃ n) (A : Matrix m m R) :
     |((reindex e₁ e₂) A).det| = |A.det| :=
@@ -180,5 +181,5 @@ lemma Matrix.isTotallyUnimodular_of_testTotallyUnimodularFast {m n : ℕ} (A : M
     A
   have := a f.range.toFinset g.range.toFinset hfg
   rw [square_set_submatrix, hee, in_signTypeCastRange_iff_abs (((reindex e₁ e₂) (A.submatrix f g))).det] at this
-  rw [←Matrix.det_reindex_self_self e₁ e₂ (A.submatrix f g)]
+  rw [←Matrix.abs_det_reindex_self_self e₁ e₂ (A.submatrix f g)]
   exact this

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -58,6 +58,16 @@ def Matrix.square_set_submatrix {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ)
       ))
 
 /-- Faster algorithm for testing total unimodularity but without formal guarantees. -/
+def Matrix.testTotallyUnimodularFaster {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) : Bool :=
+  (∀ k : ℕ, k < min m n → ∀ x : Fin k → Fin m, ∀ y : Fin k → Fin n, (A.submatrix x y).det ∈ SignType.cast.range) ∧ (
+    if hmn : m = n
+      then (A.submatrix id (finCongr hmn)).det ∈ SignType.cast.range
+    else if m < n
+      then (∀ y : Fin m → Fin n, (A.submatrix id y).det ∈ SignType.cast.range)
+      else (∀ x : Fin n → Fin m, (A.submatrix x id).det ∈ SignType.cast.range)
+  )
+
+/-- Faster algorithm for testing total unimodularity without permutation with pending formal guarantees. -/
 def Matrix.testTotallyUnimodularFastest {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) : Bool :=
   ∀ (r : Finset (Fin m)) (c : Finset (Fin n)) (h : #r = #c),
     (A.square_set_submatrix r c h).det ∈ SignType.cast.range

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -89,17 +89,32 @@ lemma Set.range_eq_range_iff_exists_comp_equiv {α β γ : Type}
     let j := fun (a : α) =>
       have : ∃ (b : β), g b = f a := by
         simp_rw [range, Set.ext_iff] at hfg
-        have := (hfg (f a)).→ (by simp)
-        exact this
-      this.choose
-    have hji : j.Injective := by sorry
-    have hjs : j.Surjective := by sorry
-    use Equiv.ofBijective j ⟨hji, hjs⟩
-    simp only [Function.comp_def, funext_iff, Equiv.ofBijective_apply]
-    unfold j
-    intro x
-    simp only
-    sorry
+        exact (hfg (f a)).→ (by simp)
+      this
+    let rj := fun (b : β) =>
+      have : ∃ (a : α), f a = g b := by
+        simp_rw [range, Set.ext_iff] at hfg
+        exact (hfg (g b)).← (by simp)
+      this
+    use Equiv.ofBijective (fun a => (j a).choose) ⟨fun a₁ a₂ haa =>
+      by
+        simp only at haa
+        have ha₁ := (j a₁).choose_spec
+        rw [haa] at ha₁
+        have ha₂ := (j a₂).choose_spec
+        rw [ha₁] at ha₂
+        exact hf ha₂,
+      by
+        rw [Function.surjective_iff_hasRightInverse]
+        use (fun b => (rj b).choose)
+        intro b
+        have := (j ((fun b => (rj b).choose) b)).choose_spec
+        simp only [(rj b).choose_spec] at this ⊢
+        apply hg
+        exact this⟩
+    simp only [Function.comp_def, Equiv.ofBijective_apply]
+    ext x
+    exact (j x).choose_spec.symm
   · intro ⟨e, he⟩
     simp_rw [range]
     ext x
@@ -149,18 +164,25 @@ lemma Matrix.isTotallyUnimodular_of_testTotallyUnimodularFastest {m n : ℕ} (A 
         p.val < #{ x // x ∈ f.range.toFinset } := Fin.isLt p
         _ = _ := by simp_all only [Fintype.card_coe])) f g
     (by
+      intro a₁ a₂ haa
       sorry)
     (by
+      intro a₁ a₂ haa
       sorry)
     hf hg
     (by
       simp only [Function.range, Set.toFinset_range, Fin.getElem_fin, ←Finset.univ_filter_mem_range]
       ext x
-      sorry)
+      constructor <;> intro h <;> simp only [Set.mem_range, Finset.univ_filter_exists] at h ⊢
+      · sorry
+      · sorry
+      )
     (by
       simp only [Function.range, Set.toFinset_range, Fin.getElem_fin, ←Finset.univ_filter_mem_range]
       ext x
-      sorry)
+      constructor <;> intro h <;> simp only [Set.mem_range, Finset.univ_filter_exists] at h ⊢
+      · sorry
+      · sorry)
     A
   have := a f.range.toFinset g.range.toFinset hfg
   rw [square_set_submatrix, hee, in_signTypeCastRange_iff_abs (((reindex e₁ e₂) (A.submatrix f g))).det] at this

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -111,7 +111,6 @@ lemma Set.range_eq_range_iff_exists_comp_equiv {α β γ : Type}
     · use e.symm w
       rw [Equiv.apply_symm_apply]
 
--- (fun x => (Finset.sort (fun x1 x2 => x1 ≤ x2) q)[x]).range
 lemma Set.range_of_list_get {α : Type} [DecidableEq α] {n : ℕ} {s : List α} (hn : n = s.length) :
     (fun x : Fin n => s[x]).range = s.toFinset := by
   ext x

--- a/Seymour/Matrix/TotalUnimodularityTest.lean
+++ b/Seymour/Matrix/TotalUnimodularityTest.lean
@@ -56,7 +56,7 @@ abbrev Matrix.square_set_submatrix {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ)
     exact Fin.isLt p))
 
 /-- Faster algorithm for testing total unimodularity without permutation with pending formal guarantees. -/
-def Matrix.testTotallyUnimodularFastest {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) : Bool :=
+def Matrix.testTotallyUnimodularFast {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) : Bool :=
   ∀ (r : Finset (Fin m)) (c : Finset (Fin n)) (h : #r = #c),
     (A.square_set_submatrix r c h).det ∈ SignType.cast.range
 
@@ -138,8 +138,8 @@ lemma Matrix.submatrix_eq_submatrix_reindex {r c n o p q : Type}
 
 /-- A fast version of `Matrix.testTotallyUnimodular` which doesn't test every permutation. -/
 lemma Matrix.isTotallyUnimodular_of_testTotallyUnimodularFast {m n : ℕ} (A : Matrix (Fin m) (Fin n) ℚ) :
-    A.testTotallyUnimodularFastest → A.IsTotallyUnimodular := by
-  rw [testTotallyUnimodularFastest]
+    A.testTotallyUnimodularFast → A.IsTotallyUnimodular := by
+  rw [testTotallyUnimodularFast]
   intro a k f g hf hg
   simp_all only [Fintype.card_coe, Function.range, Fin.getElem_fin,
     decide_eq_true_eq]

--- a/Seymour/Matroid/Notions/Regularity.lean
+++ b/Seymour/Matroid/Notions/Regularity.lean
@@ -75,7 +75,14 @@ private def Matrix.auxZ2_unexpand : Lean.PrettyPrinter.Unexpander
   | `($_ $x) => `($(x).$(Lean.mkIdent `auxZ2))
   | _ => throw ()
 
-variable {α : Type} [DecidableEq α]
+variable {α β : Type}
+
+/-- Matroids are regular up to map equivalence -/
+@[simp]
+lemma Matroid.IsRegular.mapEquiv {M : Matroid α} {f : α ≃ β} : (M.mapEquiv f).IsRegular ↔ M.IsRegular :=
+  sorry
+
+variable [DecidableEq α]
 
 private lemma Matrix.IsTotallyUnimodular.intCast_det_eq_auxZ2_det [Fintype α] {A : Matrix α α ℤ}
     (hA : A.IsTotallyUnimodular) :

--- a/Seymour/Matroid/Notions/Regularity.lean
+++ b/Seymour/Matroid/Notions/Regularity.lean
@@ -75,11 +75,11 @@ private def Matrix.auxZ2_unexpand : Lean.PrettyPrinter.Unexpander
   | `($_ $x) => `($(x).$(Lean.mkIdent `auxZ2))
   | _ => throw ()
 
-variable {α β : Type}
+variable {α : Type}
 
 /-- Matroids are regular up to map equivalence -/
 @[simp]
-lemma Matroid.IsRegular.mapEquiv {M : Matroid α} {f : α ≃ β} : (M.mapEquiv f).IsRegular ↔ M.IsRegular :=
+lemma Matroid.isRegular_mapEquiv_iff {β : Type} (M : Matroid α) (f : α ≃ β) : (M.mapEquiv f).IsRegular ↔ M.IsRegular :=
   sorry
 
 variable [DecidableEq α]

--- a/Seymour/Matroid/Notions/Regularity.lean
+++ b/Seymour/Matroid/Notions/Regularity.lean
@@ -79,8 +79,16 @@ variable {α : Type}
 
 /-- Matroids are regular up to map equivalence -/
 @[simp]
-lemma Matroid.isRegular_mapEquiv_iff {β : Type} (M : Matroid α) (f : α ≃ β) : (M.mapEquiv f).IsRegular ↔ M.IsRegular :=
-  sorry
+lemma Matroid.isRegular_mapEquiv_iff {β : Type} (M : Matroid α) (f : α ≃ β) : (M.mapEquiv f).IsRegular ↔ M.IsRegular := by
+  constructor <;> intro ⟨X, Y, A, hA, hAM⟩
+  on_goal 1 => let f' := f.symm
+  on_goal 2 => let f' := f
+  all_goals
+    use f' '' X
+    use f' '' Y
+    use A.submatrix (f'.image X).symm (f'.image Y).symm
+    refine ⟨Matrix.IsTotallyUnimodular.submatrix _ _ hA, ?_⟩
+    sorry
 
 variable [DecidableEq α]
 

--- a/Seymour/Matroid/Special/R10.lean
+++ b/Seymour/Matroid/Special/R10.lean
@@ -41,6 +41,7 @@ def matroidR10 : StandardRepr (Fin 10) Z2 where
 @[simp] theorem matroidR10_Y_eq : matroidR10.Y = { x | 5 ≤ x.val } := rfl
 @[simp] theorem matroidR10_B_eq : matroidR10.B = matroidR10_B_Z2_coe := rfl
 
+@[simp]
 theorem matroidR10.isRegular : matroidR10.toMatroid.IsRegular := by
   rw [StandardRepr.toMatroid_isRegular_iff_hasTuSigning]
   use matroidR10_B_ℚ_coe

--- a/Seymour/Matroid/Special/R10.lean
+++ b/Seymour/Matroid/Special/R10.lean
@@ -8,7 +8,7 @@ def matroidR10_B_ℚ : Matrix (Fin 5) (Fin 5) ℚ :=
   matroidR10_B_Z2.map (·.val)
 
 theorem matroidR10_B_ℚ_TU : matroidR10_B_ℚ.IsTotallyUnimodular :=
-  matroidR10_B_ℚ.isTotallyUnimodular_of_testTotallyUnimodularFastest (by decide +kernel)
+  matroidR10_B_ℚ.isTotallyUnimodular_of_testTotallyUnimodularFast (by decide +kernel)
 
 def matroidR10_B_Z2_coe : Matrix { x : Fin 10 | x.val < 5 } { x : Fin 10 | 5 ≤ x.val } Z2 :=
   matroidR10_B_Z2.submatrix

--- a/Seymour/Matroid/Special/R10.lean
+++ b/Seymour/Matroid/Special/R10.lean
@@ -1,0 +1,53 @@
+import Seymour.Matroid.Notions.Graphicness
+import Seymour.Matrix.TotalUnimodularityTest
+
+def matroidR10_B_Z2 : Matrix (Fin 5) (Fin 5) Z2 :=
+  !![1, 0, 0, 1, 1; 1, 1, 0, 0, 1; 0, 1, 1, 0, 1; 0, 0, 1, 1, 1; 1, 1, 1, 1, 1]
+
+def matroidR10_B_ℚ : Matrix (Fin 5) (Fin 5) ℚ :=
+  matroidR10_B_Z2.map (·.val)
+
+theorem matroidR10_B_ℚ_TU : matroidR10_B_ℚ.IsTotallyUnimodular :=
+  matroidR10_B_ℚ.isTotallyUnimodular_of_testTotallyUnimodularFastest (by decide +kernel)
+
+def matroidR10_B_Z2_coe : Matrix { x : Fin 10 | x.val < 5 } { x : Fin 10 | 5 ≤ x.val } Z2 :=
+  matroidR10_B_Z2.submatrix
+    (fun i => ⟨i.val, i.property⟩)
+    (fun j => ⟨j.val - 5, by omega⟩)
+
+def matroidR10_B_ℚ_coe : Matrix { x : Fin 10 | x.val < 5 } { x : Fin 10 | 5 ≤ x.val } ℚ :=
+  matroidR10_B_Z2_coe.map (·.val)
+
+theorem matroidR10_B_ℚ_coe_eq_coe_matroidR10_B_ℚ : matroidR10_B_ℚ_coe = matroidR10_B_ℚ.submatrix
+    (fun i => ⟨i.val, i.property⟩)
+    (fun j => ⟨j.val - 5, by omega⟩) := by
+  simp_all only [Set.coe_setOf, Set.mem_setOf_eq]
+  rfl
+
+/-- Matroid R10. -/
+def matroidR10 : StandardRepr (Fin 10) Z2 where
+  X := { x | x.val < 5 }
+  Y := { x | 5 ≤ x.val }
+  hXY := by
+    rw [Set.disjoint_iff_inter_eq_empty]
+    ext x
+    simp
+  -- K. Truemper, 9.2.13
+  B := matroidR10_B_Z2_coe
+  decmemX := (·.val.decLt 5)
+  decmemY := Fin.decLe 5
+
+@[simp] theorem matroidR10_X_eq : matroidR10.X = { x | x.val < 5 } := rfl
+@[simp] theorem matroidR10_Y_eq : matroidR10.Y = { x | 5 ≤ x.val } := rfl
+@[simp] theorem matroidR10_B_eq : matroidR10.B = matroidR10_B_Z2_coe := rfl
+
+theorem matroidR10.IsRegular : matroidR10.toMatroid.IsRegular := by
+  rw [StandardRepr.toMatroid_isRegular_iff_hasTuSigning]
+  use matroidR10_B_ℚ_coe
+  simp_rw [Matrix.IsTuSigningOf]
+  refine ⟨?_, fun i j => ?_⟩
+  · rw [matroidR10_B_ℚ_coe_eq_coe_matroidR10_B_ℚ]
+    sorry
+  · rw [matroidR10_B_ℚ_coe, matroidR10_B_eq]
+    simp_rw [Set.coe_setOf, Matrix.map_apply, abs_eq_self]
+    exact Nat.cast_nonneg _

--- a/Seymour/Matroid/Special/R10.lean
+++ b/Seymour/Matroid/Special/R10.lean
@@ -48,7 +48,7 @@ theorem matroidR10.isRegular : matroidR10.toMatroid.IsRegular := by
   simp_rw [Matrix.IsTuSigningOf]
   refine ⟨?_, fun i j => ?_⟩
   · rw [matroidR10_B_ℚ_coe_eq_coe_matroidR10_B_ℚ]
-    sorry
+    exact Matrix.IsTotallyUnimodular.submatrix _ _ matroidR10_B_ℚ_TU
   · rw [matroidR10_B_ℚ_coe, matroidR10_B_eq]
     simp_rw [Set.coe_setOf, Matrix.map_apply, abs_eq_self]
     exact Nat.cast_nonneg _

--- a/Seymour/Matroid/Special/R10.lean
+++ b/Seymour/Matroid/Special/R10.lean
@@ -41,7 +41,7 @@ def matroidR10 : StandardRepr (Fin 10) Z2 where
 @[simp] theorem matroidR10_Y_eq : matroidR10.Y = { x | 5 ≤ x.val } := rfl
 @[simp] theorem matroidR10_B_eq : matroidR10.B = matroidR10_B_Z2_coe := rfl
 
-theorem matroidR10.IsRegular : matroidR10.toMatroid.IsRegular := by
+theorem matroidR10.isRegular : matroidR10.toMatroid.IsRegular := by
   rw [StandardRepr.toMatroid_isRegular_iff_hasTuSigning]
   use matroidR10_B_ℚ_coe
   simp_rw [Matrix.IsTuSigningOf]


### PR DESCRIPTION
We _begin_ proving a TU tester that takes advantage of well-defined determinants up to matrix permutation. Unfortunately, I can't find good lemmas for proving theorems about matrices regarding ordering. This allows us to check if `R10` is TU in a reasonable amount of time using kernel-level deciding (`native_decide` is, as always, much faster, but it adds a lot of trusted code). The check takes a few seconds on my local machine.

Closes #53.