### PR TITLE
fix: drop ite_some_none_eq_some usage

### DIFF
--- a/Seymour/Matroid/Notions/Regularity.lean
+++ b/Seymour/Matroid/Notions/Regularity.lean
@@ -165,7 +165,7 @@ private lemma Matrix.exists_finite_allColsIn {X Y R : Type} [Fintype X] [Decidab
   · let S : Set (X → V) := Set.univ
     let S' : Set (X → R) := (fun v : X → V => fun x : X => (v x).val) '' S
     have hCS' : C ⊆ S' := by
-      rintro x ⟨w, rfl⟩
+      rintro - ⟨w, rfl⟩
       exact ⟨(fun j => ⟨(A · w) j, hAV j w⟩), trivial, rfl⟩
     let e : Y' ↪ C := ⟨fun i => ⟨(A · i), by use i⟩, fun ⟨_, w₁, ⟨y₁, hy₁⟩, _⟩ ⟨_, w₂, ⟨y₂, hy₂⟩, _⟩ hzz => by
       simp_all only [Subtype.mk.injEq, C, Y']

--- a/Seymour/Matroid/Notions/Regularity.lean
+++ b/Seymour/Matroid/Notions/Regularity.lean
@@ -165,9 +165,8 @@ private lemma Matrix.exists_finite_allColsIn {X Y R : Type} [Fintype X] [Decidab
   · let S : Set (X → V) := Set.univ
     let S' : Set (X → R) := (fun v : X → V => fun x : X => (v x).val) '' S
     have hCS' : C ⊆ S' := by
-      intro x _
-      use (fun j => ⟨x j, by aesop⟩)
-      exact ite_some_none_eq_some.→ rfl
+      rintro x ⟨w, rfl⟩
+      exact ⟨(fun j => ⟨(A · w) j, hAV j w⟩), trivial, rfl⟩
     let e : Y' ↪ C := ⟨fun i => ⟨(A · i), by use i⟩, fun ⟨_, w₁, ⟨y₁, hy₁⟩, _⟩ ⟨_, w₂, ⟨y₂, hy₂⟩, _⟩ hzz => by
       simp_all only [Subtype.mk.injEq, C, Y']
       subst hy₁ hy₂


### PR DESCRIPTION
we also remove the use of `aesop` by directly refined-introducing the hypothesis, substituting it, and using it directly in our proof construction

closes https://github.com/Ivan-Sergeyev/seymour/issues/63