### PR TITLE
chore(longTableauPivot): init proof of indp preservation

### DIFF
--- a/Seymour/Matrix/Pivoting.lean
+++ b/Seymour/Matrix/Pivoting.lean
@@ -19,6 +19,35 @@ private lemma Matrix.mulRow_det [DecidableEq X] [Fintype X] [CommRing F] (A : Ma
     (A.mulRow x q).det = q * A.det := by
   rw [Matrix.mulRow, Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
 
+/-- Multiplying a row `x` by a non-zero factor preserves linear independence on the transpose. -/
+private lemma Matrix.mulRow_linearIndepOn [DecidableEq X] [Field F] (A : Matrix X Y F) (x : X)
+    {q : F} (hq : q ≠ 0) (S : Set Y) :
+    LinearIndepOn F (A.mulRow x q).transpose S ↔ LinearIndepOn F A.transpose S := by
+  rw [Matrix.mulRow, ← Matrix.updateCol_transpose, linearIndepOn_iffₛ, linearIndepOn_iffₛ]
+  constructor
+  all_goals
+    intro h
+    peel h with f hf g hg h
+    refine fun hfgl => h ?_
+    rw [Finsupp.linearCombination_apply, Finsupp.linearCombination_apply,
+      Finsupp.sum, Finsupp.sum] at hfgl ⊢
+    ext x'
+    rw [funext_iff] at hfgl
+    specialize hfgl x'
+    simp_rw [Finset.sum_apply, Pi.smul_apply, smul_eq_mul] at hfgl ⊢
+    simp_rw [Matrix.updateCol_apply, Pi.smul_apply] at hfgl ⊢
+    simp only [smul_eq_mul, mul_ite, Finset.sum_ite_irrel] at hfgl ⊢
+  · split_ifs with hx'
+    · subst hx'
+      simp_rw [transpose_apply] at hfgl
+      sorry
+    · exact hfgl
+  · split_ifs at hfgl with hx'
+    · subst hx'
+      simp_rw [transpose_apply]
+      sorry
+    · exact hfgl
+
 /-- Multiplying a row by a `0, ±1` factor preserves total unimodularity. -/
 private lemma Matrix.IsTotallyUnimodular.mulRow [DecidableEq X] [CommRing F] {A : Matrix X Y F}
     (hA : A.IsTotallyUnimodular) (x : X) {q : F} (hq : q ∈ SignType.cast.range) :
@@ -48,6 +77,12 @@ private lemma Matrix.IsTotallyUnimodular.mulRow [DecidableEq X] [CommRing F] {A 
 private def Matrix.addMultiples [DecidableEq X] [Add F] [SMul F F] (A : Matrix X Y F) (x : X) (q : X → F) :
     Matrix X Y F :=
   fun i : X => if i = x then A x else A i + q i • A x
+
+/-- Using the `addMultiples` operator preserves linear independence on the transpose. -/
+private lemma Matrix.addMultiples_linearIndepOn [DecidableEq X] [Field F] (A : Matrix X Y F) (x : X)
+    {q : X → F} (S : Set Y):
+    LinearIndepOn F (A.addMultiples x q).transpose S ↔ LinearIndepOn F A.transpose S := by
+  sorry
 
 /-- Adding multiples of a row to all other rows of a matrix does not change the determinant of the matrix. -/
 private lemma Matrix.addMultiples_det [DecidableEq X] [Fintype X] [CommRing F] (A : Matrix X X F) (x : X) (q : X → F) :
@@ -188,6 +223,11 @@ lemma Matrix.IsTotallyUnimodular.longTableauPivot [DecidableEq X] [Field F] {A :
   · rw [inv_eq_self_of_in_signTypeCastRange] <;> exact hA.apply x y
   exact (hA.addPivotMultiples hxy).mulRow x hAxy
 
+/-- Long tableau pivot preserves linear independence on transpose. -/
+lemma Matrix.longTableauPivot_linearIndependent [DecidableEq X] [Field F] {A : Matrix X Y F}
+    {x : X} {y : Y} (hxy : A x y ≠ 0) (S : Set Y) :
+    LinearIndepOn F (A.longTableauPivot x y).transpose S ↔ LinearIndepOn F A.transpose S := by
+  rw [Matrix.longTableauPivot_eq, Matrix.mulRow_linearIndepOn _ _ (one_div_ne_zero hxy), Matrix.addMultiples_linearIndepOn]
 
 -- ## Short-tableau pivoting
 

--- a/Seymour/Matrix/Pivoting.lean
+++ b/Seymour/Matrix/Pivoting.lean
@@ -97,16 +97,35 @@ private lemma Matrix.IsTotallyUnimodular.mulRow [DecidableEq X] [CommRing F] {A 
     convert hA k f g hf hg using 2
     simp_all [Matrix.submatrix, Matrix.mulRow]
 
+/-- Add column `x` of `A` multiplied by `q` (where `q` is different for each column) to every column of `A` except `x`. -/
+private def Matrix.addColumnMultiples [DecidableEq Y] [Add F] [SMul F F] (A : Matrix X Y F) (y : Y) (q : Y → F) :
+    Matrix X Y F :=
+  fun i j => if j = y then A i y else A i j + q j • A i y
+
+/-- Using the `addColumnMultiples` operator preserves linear independence on the transpose. -/
+private lemma Matrix.addColumnMultiples_linearIndepOn [DecidableEq Y] [Field F] (A : Matrix X Y F) (y : Y)
+    {q : Y → F} (S : Set X) :
+    LinearIndepOn F (A.addColumnMultiples y q) S ↔ LinearIndepOn F A S := by
+  sorry
+
 /-- Add row `x` of `A` multiplied by factor `q` (where `q` is different for each row) to every row of `A` except `x`. -/
 private def Matrix.addMultiples [DecidableEq X] [Add F] [SMul F F] (A : Matrix X Y F) (x : X) (q : X → F) :
     Matrix X Y F :=
   fun i : X => if i = x then A x else A i + q i • A x
 
+private lemma Matrix.addMultiples_tranpose_eq [DecidableEq X] [Add F] [SMul F F] (A : Matrix X Y F) (x : X) (q : X → F) :
+    (A.addMultiples x q).transpose = A.transpose.addColumnMultiples x q := by
+  unfold Matrix.addMultiples Matrix.addColumnMultiples
+  ext i j
+  dsimp only [Matrix.transpose_apply]
+  split_ifs <;> rfl
+
 /-- Using the `addMultiples` operator preserves linear independence on the transpose. -/
 private lemma Matrix.addMultiples_linearIndepOn [DecidableEq X] [Field F] (A : Matrix X Y F) (x : X)
-    {q : X → F} (S : Set Y):
+    {q : X → F} (S : Set Y) :
     LinearIndepOn F (A.addMultiples x q).transpose S ↔ LinearIndepOn F A.transpose S := by
-  sorry
+  rw [Matrix.addMultiples_tranpose_eq]
+  exact Matrix.addColumnMultiples_linearIndepOn A.transpose x S
 
 /-- Adding multiples of a row to all other rows of a matrix does not change the determinant of the matrix. -/
 private lemma Matrix.addMultiples_det [DecidableEq X] [Fintype X] [CommRing F] (A : Matrix X X F) (x : X) (q : X → F) :

--- a/Seymour/Matrix/Pivoting.lean
+++ b/Seymour/Matrix/Pivoting.lean
@@ -36,9 +36,8 @@ private lemma Matrix.mulCol_linearIndepOn [DecidableEq Y] [Field F] (A : Matrix 
     ext x'
     rw [funext_iff] at hfgl
     specialize hfgl x'
-    simp_rw [Finset.sum_apply, Pi.smul_apply, smul_eq_mul] at hfgl ⊢
-    simp_rw [Matrix.updateCol_apply, Pi.smul_apply] at hfgl ⊢
-    simp only [smul_eq_mul, mul_ite, Finset.sum_ite_irrel] at hfgl ⊢
+    simp_rw [Finset.sum_apply, Pi.smul_apply, Matrix.updateCol_apply, Pi.smul_apply,
+      smul_eq_mul, mul_ite, Finset.sum_ite_irrel] at hfgl ⊢
   · split_ifs with hx'
     · subst hx'
       conv => enter [1, 2, x]; rw [←mul_assoc, mul_comm (f x), mul_assoc]
@@ -112,7 +111,7 @@ private lemma Matrix.addMultiples_linearIndepOn [DecidableEq X] [Field F] (A : M
 /-- Adding multiples of a row to all other rows of a matrix does not change the determinant of the matrix. -/
 private lemma Matrix.addMultiples_det [DecidableEq X] [Fintype X] [CommRing F] (A : Matrix X X F) (x : X) (q : X → F) :
     (A.addMultiples x q).det = A.det := by
-  apply Matrix.det_eq_of_forall_row_eq_smul_add_const (fun i : X => if i = x then 0 else q i) x (by simp)
+  apply Matrix.det_eq_of_forall_row_eq_smul_add_const (fun i : X => if i = x then 0 else q i) x (if_pos rfl)
   unfold Matrix.addMultiples
   aesop
 

--- a/Seymour/Matrix/Pivoting.lean
+++ b/Seymour/Matrix/Pivoting.lean
@@ -23,7 +23,7 @@ private lemma Matrix.mulRow_det [DecidableEq X] [Fintype X] [CommRing F] (A : Ma
 private lemma Matrix.mulRow_linearIndepOn [DecidableEq X] [Field F] (A : Matrix X Y F) (x : X)
     {q : F} (hq : q ≠ 0) (S : Set Y) :
     LinearIndepOn F (A.mulRow x q).transpose S ↔ LinearIndepOn F A.transpose S := by
-  rw [Matrix.mulRow, ← Matrix.updateCol_transpose, linearIndepOn_iffₛ, linearIndepOn_iffₛ]
+  rw [Matrix.mulRow, ←Matrix.updateCol_transpose, linearIndepOn_iffₛ, linearIndepOn_iffₛ]
   constructor
   all_goals
     intro h
@@ -40,12 +40,18 @@ private lemma Matrix.mulRow_linearIndepOn [DecidableEq X] [Field F] (A : Matrix 
   · split_ifs with hx'
     · subst hx'
       simp_rw [transpose_apply] at hfgl
-      sorry
+      conv => enter [1, 2, x]; rw [←mul_assoc, mul_comm (f x), mul_assoc]
+      conv => enter [2, 2, x]; rw [←mul_assoc, mul_comm (g x), mul_assoc]
+      rw [← Finset.mul_sum, ← Finset.mul_sum]
+      exact congrArg (HMul.hMul q) hfgl
     · exact hfgl
   · split_ifs at hfgl with hx'
     · subst hx'
       simp_rw [transpose_apply]
-      sorry
+      conv at hfgl => enter [1, 2, x]; rw [←mul_assoc, mul_comm (f x), mul_assoc]
+      conv at hfgl => enter [2, 2, x]; rw [←mul_assoc, mul_comm (g x), mul_assoc]
+      rw [← Finset.mul_sum, ← Finset.mul_sum] at hfgl
+      exact mul_left_cancel₀ hq hfgl
     · exact hfgl
 
 /-- Multiplying a row by a `0, ±1` factor preserves total unimodularity. -/

--- a/Seymour/Matroid/Constructors/StandardRepresentation.lean
+++ b/Seymour/Matroid/Constructors/StandardRepresentation.lean
@@ -419,7 +419,10 @@ lemma VectorMatroid.exists_standardRepr [DivisionRing R] (M : VectorMatroid α R
 
 lemma VectorMatroid.longTableauPivot [Field R] (V : VectorMatroid α R) {x : V.X} {y : V.Y} (hVxy : V.A x y ≠ 0) :
     (VectorMatroid.mk V.X V.Y (V.A.longTableauPivot x y)).toMatroid = V.toMatroid := by
-  sorry
+  ext I hI
+  · rfl
+  · rw [VectorMatroid.toMatroid_indep, VectorMatroid.toMatroid_indep, VectorMatroid.IndepCols, VectorMatroid.IndepCols, and_congr_right_iff]
+    exact fun h => Matrix.longTableauPivot_linearIndependent hVxy _
 
 /-- Every vector matroid whose full representation matrix is totally unimodular has a standard representation whose rows are
     a given base and the standard representation matrix is totally unimodular. -/


### PR DESCRIPTION
mainly to claim `VectorMatroid.longTableauPivot`, but this finishes the proof of `mulRow` preserving linear independence when transposed