### PR TITLE
finiteness assumptions decoupled from the definitions of 1/2/3-sum

### DIFF
--- a/Seymour.lean
+++ b/Seymour.lean
@@ -97,15 +97,13 @@ recall Matroid.IsSum1of {α : Type*} [DecidableEq α] (M Mₗ Mᵣ : Matroid α)
   ∃ hXY : Disjoint Sₗ.X Sᵣ.Y,
   ∃ hYX : Disjoint Sₗ.Y Sᵣ.X,
   standardReprSum1 hXY hYX = some S
-  ∧ Finite Sₗ.X
-  ∧ Finite Sᵣ.X
   ∧ S.toMatroid = M
   ∧ Sₗ.toMatroid = Mₗ
   ∧ Sᵣ.toMatroid = Mᵣ
 
 -- [theorem] any 1-sum of regular matroids is a regular matroid
 recall Matroid.IsSum1of.isRegular {α : Type*} [DecidableEq α] {M Mₗ Mᵣ : Matroid α} :
-  M.IsSum1of Mₗ Mᵣ → Mₗ.IsRegular → Mᵣ.IsRegular → M.IsRegular
+  M.IsSum1of Mₗ Mᵣ → M.RankFinite → Mₗ.IsRegular → Mᵣ.IsRegular → M.IsRegular
 /--
 info: 'Matroid.IsSum1of.isRegular' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
@@ -153,15 +151,13 @@ recall Matroid.IsSum2of {α : Type*} [DecidableEq α] (M Mₗ Mᵣ : Matroid α)
   ∃ hXY : Disjoint Sₗ.X Sᵣ.Y,
   ∃ hYX : Disjoint Sₗ.Y Sᵣ.X,
   standardReprSum2 hXX hYY hXY hYX = some S
-  ∧ Finite Sₗ.X
-  ∧ Finite Sᵣ.X
   ∧ S.toMatroid = M
   ∧ Sₗ.toMatroid = Mₗ
   ∧ Sᵣ.toMatroid = Mᵣ
 
 -- [theorem] any 2-sum of regular matroids is a regular matroid
 recall Matroid.IsSum2of.isRegular {α : Type*} [DecidableEq α] {M Mₗ Mᵣ : Matroid α} :
-  M.IsSum2of Mₗ Mᵣ → Mₗ.IsRegular → Mᵣ.IsRegular → M.IsRegular
+  M.IsSum2of Mₗ Mᵣ → M.RankFinite → Mₗ.IsRegular → Mᵣ.IsRegular → M.IsRegular
 /--
 info: 'Matroid.IsSum2of.isRegular' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
@@ -307,15 +303,13 @@ recall Matroid.IsSum3of {α : Type*} [DecidableEq α] (M Mₗ Mᵣ : Matroid α)
   ∃ hXY : Disjoint Sₗ.X Sᵣ.Y,
   ∃ hYX : Disjoint Sₗ.Y Sᵣ.X,
   standardReprSum3 hXX hYY hXY hYX = some S
-  ∧ Finite Sₗ.X
-  ∧ Finite Sᵣ.X
   ∧ S.toMatroid = M
   ∧ Sₗ.toMatroid = Mₗ
   ∧ Sᵣ.toMatroid = Mᵣ
 
 -- [theorem] any 3-sum of regular matroids is a regular matroid
 recall Matroid.IsSum3of.isRegular {α : Type*} [DecidableEq α] {M Mₗ Mᵣ : Matroid α} :
-  M.IsSum3of Mₗ Mᵣ → Mₗ.IsRegular → Mᵣ.IsRegular → M.IsRegular
+  M.IsSum3of Mₗ Mᵣ → M.RankFinite → Mₗ.IsRegular → Mᵣ.IsRegular → M.IsRegular
 /--
 info: 'Matroid.IsSum3of.isRegular' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/

--- a/Seymour/Matroid/Sum1.lean
+++ b/Seymour/Matroid/Sum1.lean
@@ -46,8 +46,6 @@ def Matroid.IsSum1of (M : Matroid α) (Mₗ Mᵣ : Matroid α) : Prop :=
   ∃ hXY : Sₗ.X ⫗ Sᵣ.Y,
   ∃ hYX : Sₗ.Y ⫗ Sᵣ.X,
   standardReprSum1 hXY hYX = some S
-  ∧ Finite Sₗ.X
-  ∧ Finite Sᵣ.X
   ∧ S.toMatroid = M
   ∧ Sₗ.toMatroid = Mₗ
   ∧ Sᵣ.toMatroid = Mᵣ
@@ -83,7 +81,7 @@ lemma standardReprSum1_Y_eq {Sₗ Sᵣ S : StandardRepr α Z2} {hXY : Sₗ.X ⫗
 
 lemma Matroid.IsSum1of.E_eq (M : Matroid α) (Mₗ Mᵣ : Matroid α) (hMMM : M.IsSum1of Mₗ Mᵣ) :
     M.E = Mₗ.E ∪ Mᵣ.E := by
-  obtain ⟨S, _, _, _, _, hS, _, _, rfl, rfl, rfl⟩ := hMMM
+  obtain ⟨S, _, _, _, _, hS, rfl, rfl, rfl⟩ := hMMM
   have hX := standardReprSum1_X_eq hS
   have hY := standardReprSum1_Y_eq hS
   simp only [StandardRepr.toMatroid_E]
@@ -211,9 +209,11 @@ lemma standardReprSum1_hasTuSigning {Sₗ Sᵣ S : StandardRepr α Z2} {hXY : S�
 /-- Any 1-sum of regular matroids is a regular matroid.
     This is part one (of three) of the easy direction of the Seymour's theorem. -/
 theorem Matroid.IsSum1of.isRegular {M Mₗ Mᵣ : Matroid α}
-    (hMMM : M.IsSum1of Mₗ Mᵣ) (hMₗ : Mₗ.IsRegular) (hMᵣ : Mᵣ.IsRegular) :
+    (hMMM : M.IsSum1of Mₗ Mᵣ) (hM : M.RankFinite) (hMₗ : Mₗ.IsRegular) (hMᵣ : Mᵣ.IsRegular) :
     M.IsRegular := by
-  obtain ⟨S, _, _, _, _, hS, _, _, rfl, rfl, rfl⟩ := hMMM
-  have : Finite S.X := standardReprSum1_X_eq hS ▸ Finite.Set.finite_union ..
+  obtain ⟨S, Sₗ, Sᵣ, _, _, hSSS, rfl, rfl, rfl⟩ := hMMM
+  have hX : Finite S.X := S.finite_X_of_toMatroid_rankFinite hM
+  obtain ⟨hXₗ, hXᵣ⟩ : Finite Sₗ.X ∧ Finite Sᵣ.X
+  · simpa [standardReprSum1_X_eq hSSS, Set.finite_coe_iff] using hX
   rw [StandardRepr.toMatroid_isRegular_iff_hasTuSigning] at hMₗ hMᵣ ⊢
-  exact standardReprSum1_hasTuSigning hMₗ hMᵣ hS
+  exact standardReprSum1_hasTuSigning hMₗ hMᵣ hSSS

--- a/Seymour/Matroid/Sum2.lean
+++ b/Seymour/Matroid/Sum2.lean
@@ -148,8 +148,6 @@ def Matroid.IsSum2of {α : Type*} [DecidableEq α] (M : Matroid α) (Mₗ Mᵣ :
   ∃ hXY : Sₗ.X ⫗ Sᵣ.Y,
   ∃ hYX : Sₗ.Y ⫗ Sᵣ.X,
   standardReprSum2 hXX hYY hXY hYX = some S
-  ∧ Finite Sₗ.X
-  ∧ Finite Sᵣ.X
   ∧ S.toMatroid = M
   ∧ Sₗ.toMatroid = Mₗ
   ∧ Sᵣ.toMatroid = Mᵣ
@@ -389,7 +387,7 @@ lemma standardReprSum2_hasTuSigning {Sₗ Sᵣ S : StandardRepr α Z2} {x y : α
 
 lemma Matroid.IsSum2of.E_eq (M : Matroid α) (Mₗ Mᵣ : Matroid α) (hMMM : M.IsSum2of Mₗ Mᵣ) :
     M.E = Mₗ.E ∪ Mᵣ.E := by
-  obtain ⟨S, _, _, _, _, _, _, _, _, hS, _, _, rfl, rfl, rfl⟩ := hMMM
+  obtain ⟨S, _, _, _, _, _, _, _, _, hS, rfl, rfl, rfl⟩ := hMMM
   have hX := standardReprSum2_X_eq hS
   have hY := standardReprSum2_Y_eq hS
   simp only [StandardRepr.toMatroid_E]
@@ -398,9 +396,11 @@ lemma Matroid.IsSum2of.E_eq (M : Matroid α) (Mₗ Mᵣ : Matroid α) (hMMM : M.
 /-- Any 2-sum of regular matroids is a regular matroid.
     This is part two (of three) of the easy direction of the Seymour's theorem. -/
 theorem Matroid.IsSum2of.isRegular {M Mₗ Mᵣ : Matroid α}
-    (hMMM : M.IsSum2of Mₗ Mᵣ) (hMₗ : Mₗ.IsRegular) (hMᵣ : Mᵣ.IsRegular) :
+    (hMMM : M.IsSum2of Mₗ Mᵣ) (hM : M.RankFinite) (hMₗ : Mₗ.IsRegular) (hMᵣ : Mᵣ.IsRegular) :
     M.IsRegular := by
-  obtain ⟨S, _, _, _, _, _, _, _, _, hS, _, _, rfl, rfl, rfl⟩ := hMMM
-  have : Finite S.X := standardReprSum2_X_eq hS ▸ Finite.Set.finite_union ..
+  obtain ⟨S, Sₗ, Sᵣ, _, _, _, _, _, _, hSSS, rfl, rfl, rfl⟩ := hMMM
+  have hX : Finite S.X := S.finite_X_of_toMatroid_rankFinite hM
+  obtain ⟨hXₗ, hXᵣ⟩ : Finite Sₗ.X ∧ Finite Sᵣ.X
+  · simpa [standardReprSum2_X_eq hSSS, Set.finite_coe_iff] using hX
   rw [StandardRepr.toMatroid_isRegular_iff_hasTuSigning] at hMₗ hMᵣ ⊢
-  exact standardReprSum2_hasTuSigning hMₗ hMᵣ hS
+  exact standardReprSum2_hasTuSigning hMₗ hMᵣ hSSS

--- a/Seymour/Matroid/Sum3.lean
+++ b/Seymour/Matroid/Sum3.lean
@@ -3454,15 +3454,13 @@ def Matroid.IsSum3of (M : Matroid α) (Mₗ Mᵣ : Matroid α) : Prop :=
   ∃ hXY : Sₗ.X ⫗ Sᵣ.Y,
   ∃ hYX : Sₗ.Y ⫗ Sᵣ.X,
   standardReprSum3 hXX hYY hXY hYX = some S
-  ∧ Finite Sₗ.X
-  ∧ Finite Sᵣ.X
   ∧ S.toMatroid = M
   ∧ Sₗ.toMatroid = Mₗ
   ∧ Sᵣ.toMatroid = Mᵣ
 
 lemma Matroid.IsSum3of.E_eq (M : Matroid α) (Mₗ Mᵣ : Matroid α) (hMMM : M.IsSum3of Mₗ Mᵣ) :
     M.E = Mₗ.E ∪ Mᵣ.E := by
-  obtain ⟨S, _, _, _, _, _, _, _, _, _, _, _, _, hS, _, _, rfl, rfl, rfl⟩ := hMMM
+  obtain ⟨S, _, _, _, _, _, _, _, _, _, _, _, _, hS, rfl, rfl, rfl⟩ := hMMM
   have hX := standardReprSum3_X_eq hS
   have hY := standardReprSum3_Y_eq hS
   simp only [StandardRepr.toMatroid_E]
@@ -3471,9 +3469,11 @@ lemma Matroid.IsSum3of.E_eq (M : Matroid α) (Mₗ Mᵣ : Matroid α) (hMMM : M.
 /-- Any 3-sum of two regular matroids is a regular matroid.
     This is the final part of the easy direction of the Seymour's theorem. -/
 theorem Matroid.IsSum3of.isRegular {M Mₗ Mᵣ : Matroid α}
-    (hMMM : M.IsSum3of Mₗ Mᵣ) (hMₗ : Mₗ.IsRegular) (hMᵣ : Mᵣ.IsRegular) :
+    (hMMM : M.IsSum3of Mₗ Mᵣ) (hM : M.RankFinite) (hMₗ : Mₗ.IsRegular) (hMᵣ : Mᵣ.IsRegular) :
     M.IsRegular := by
-  obtain ⟨S, _, _, _, _, _, _, _, _, _, _, _, _, hS, _, _, rfl, rfl, rfl⟩ := hMMM
-  have : Finite S.X := standardReprSum3_X_eq hS ▸ Finite.Set.finite_union ..
+  obtain ⟨S, Sₗ, Sᵣ, _, _, _, _, _, _, _, _, _, _, hSSS, rfl, rfl, rfl⟩ := hMMM
+  have hX : Finite S.X := S.finite_X_of_toMatroid_rankFinite hM
+  obtain ⟨hXₗ, hXᵣ⟩ : Finite Sₗ.X ∧ Finite Sᵣ.X
+  · simpa [standardReprSum3_X_eq hSSS, Set.finite_coe_iff] using hX
   rw [StandardRepr.toMatroid_isRegular_iff_hasTuSigning] at hMₗ hMᵣ ⊢
-  exact standardReprSum3_hasTuSigning hMₗ hMᵣ hS
+  exact standardReprSum3_hasTuSigning hMₗ hMᵣ hSSS

--- a/Seymour/Results/EasyDirection.lean
+++ b/Seymour/Results/EasyDirection.lean
@@ -14,9 +14,9 @@ inductive Matroid.IsGood : Matroid α → Prop
 | cographic {M : Matroid α} (hM : M.IsCographic) : M.IsGood
 | isomorphicR10 {M : Matroid α} {e : α ≃ Fin 10} (hM : M.mapEquiv e = matroidR10.toMatroid) : M.IsGood
 -- fork constructors
-| is1sum {M Mₗ Mᵣ : Matroid α} (hM : M.IsSum1of Mₗ Mᵣ) (hMₗ : Mₗ.IsGood) (hMᵣ : Mᵣ.IsGood) : M.IsGood
-| is2sum {M Mₗ Mᵣ : Matroid α} (hM : M.IsSum2of Mₗ Mᵣ) (hMₗ : Mₗ.IsGood) (hMᵣ : Mᵣ.IsGood) : M.IsGood
-| is3sum {M Mₗ Mᵣ : Matroid α} (hM : M.IsSum3of Mₗ Mᵣ) (hMₗ : Mₗ.IsGood) (hMᵣ : Mᵣ.IsGood) : M.IsGood
+| is1sum {M Mₗ Mᵣ : Matroid α} (hMMM : M.IsSum1of Mₗ Mᵣ) (hM : M.RankFinite) (hMₗ : Mₗ.IsGood) (hMᵣ : Mᵣ.IsGood) : M.IsGood
+| is2sum {M Mₗ Mᵣ : Matroid α} (hMMM : M.IsSum2of Mₗ Mᵣ) (hM : M.RankFinite) (hMₗ : Mₗ.IsGood) (hMᵣ : Mᵣ.IsGood) : M.IsGood
+| is3sum {M Mₗ Mᵣ : Matroid α} (hMMM : M.IsSum3of Mₗ Mᵣ) (hM : M.RankFinite) (hMₗ : Mₗ.IsGood) (hMᵣ : Mᵣ.IsGood) : M.IsGood
 
 /-- Corollary of the easy direction of the Seymour's theorem. -/
 theorem Matroid.IsGood.isRegular {M : Matroid α} (hM : M.IsGood) : M.IsRegular := by
@@ -24,6 +24,6 @@ theorem Matroid.IsGood.isRegular {M : Matroid α} (hM : M.IsGood) : M.IsRegular 
   | graphic hM => exact hM.isRegular
   | cographic hM => sorry
   | @isomorphicR10 M e hM => simp [←M.isRegular_mapEquiv_iff e, hM]
-  | is1sum hM _ _ ihₗ ihᵣ => exact hM.isRegular ihₗ ihᵣ
-  | is2sum hM _ _ ihₗ ihᵣ => exact hM.isRegular ihₗ ihᵣ
-  | is3sum hM _ _ ihₗ ihᵣ => exact hM.isRegular ihₗ ihᵣ
+  | is1sum hMMM hM _ _ ihₗ ihᵣ => exact hMMM.isRegular hM ihₗ ihᵣ
+  | is2sum hMMM hM _ _ ihₗ ihᵣ => exact hMMM.isRegular hM ihₗ ihᵣ
+  | is3sum hMMM hM _ _ ihₗ ihᵣ => exact hMMM.isRegular hM ihₗ ihᵣ


### PR DESCRIPTION
Please carefully review this PR, as it nontrivially changes the trusted code.

I believe we should merge it, as it is a natural (albeit not mandatory) consequence of fixing the hard direction, since `RankFinite` lives on the level of matroids, not on the level of their representations.

There is also a usability advantage of decoupling the finiteness assumptions from the definitions of 1-, 2-, and 3-sum. With the new version, you can use a different base for witnessing finite rank, a different base for witnessing the regularity, and another base for witnessing being 1/2/3-sum of given matroids, since these three assumptions all meet at the `Matroid` level. I think this advantage is substantial enough to mention in the paper as well.